### PR TITLE
Add GitHub-ready README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,40 @@
-# Welcome to your Expo app 👋
+# SleepBubble
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+SleepBubble is a simple React Native application built with [Expo](https://expo.dev). It allows you to toggle and view a sleep status, sending push notifications whenever the status changes.
 
-## Get started
+## Features
+
+- Toggle between **Sleeping** and **Awake** states
+- Fetch and display the current sleep status from the SleepBubble server
+- Receive push notifications using Expo Notifications
+- Works on Android, iOS and the web
+
+## Installation
 
 1. Install dependencies
-
    ```bash
    npm install
    ```
-
-2. Start the app
-
+2. Start the development server
    ```bash
-    npx expo start
+   npx expo start
    ```
+   Follow the prompts in your terminal to open the app on a simulator, emulator or physical device.
 
-In the output, you'll find options to open the app in a
+## Project Structure
 
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-## Get a fresh project
-
-When you're ready, run:
-
-```bash
-npm run reset-project
+```
+app/              # Application source
+  (tabs)/index.tsx
+assets/           # Images and fonts
+constants/        # Shared constants such as colors
+utils/            # Helper utilities
 ```
 
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+## Learn More
 
-## Learn more
+See the [Expo documentation](https://docs.expo.dev/) for guides on building, testing and deploying your app.
 
-To learn more about developing your project with Expo, look at the following resources:
+## License
 
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
-
-## Join the community
-
-Join our community of developers creating universal apps.
-
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- replace the default Expo README with a brief overview of the SleepBubble project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b905c9b88324bf095af92f1c0da7